### PR TITLE
CI/CD: `subscriptions-transport-ws` test setup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,3 +56,5 @@ libraryDependencies ++= {
     "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
   )
 }
+
+libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"

--- a/src/test/scala/io/github/dexclaimation/overlayer/websocket/Shared.scala
+++ b/src/test/scala/io/github/dexclaimation/overlayer/websocket/Shared.scala
@@ -1,0 +1,71 @@
+package io.github.dexclaimation.overlayer.websocket
+
+import akka.actor.typed.{ActorSystem, SpawnProtocol}
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.typed.scaladsl.ActorSource
+import akka.stream.{Materializer, OverflowStrategy}
+import io.github.dexclaimation.overlayer.OverTransportLayer
+import sangria.schema.{Action, Field, IntType, ObjectType, Schema, fields}
+
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.ExecutionContext
+
+object Shared {
+  implicit val testSystem: ActorSystem[SpawnProtocol.Command] = ActorSystem(OverTransportLayer.behavior,
+    "TestActorSystem"
+  )
+
+  implicit val ex: ExecutionContext = testSystem.executionContext
+
+  implicit val mat: Materializer = Materializer.createMaterializer(testSystem)
+
+  case class Ctx() {
+    val atomic = new AtomicInteger()
+    val (actorRef, publisher) = ActorSource
+      .actorRef[Int](
+        completionMatcher = {
+          case 100 => ()
+        },
+        failureMatcher = PartialFunction.empty,
+        bufferSize = 100,
+        overflowStrategy = OverflowStrategy.dropHead
+      )
+      .toMat(Sink.asPublisher(true))(Keep.both)
+      .run()
+
+    val source = Source.fromPublisher(publisher)
+  }
+
+  val ctx = Ctx()
+
+  val demoSchema = {
+    import sangria.streaming.akkaStreams._
+
+    val Query = ObjectType("Query",
+      fields[Ctx, Unit](
+        Field("state", IntType, resolve = _.ctx.atomic.get())
+      )
+    )
+
+    val Mutation = ObjectType("Mutation",
+      fields[Ctx, Unit](
+        Field("increment", IntType,
+          resolve = c => {
+            val res = c.ctx.atomic.incrementAndGet()
+            c.ctx.actorRef ! res
+            res
+          }
+        )
+      )
+    )
+
+    val Subscription = ObjectType("Subscription",
+      fields[Ctx, Unit](
+        Field.subs("state", IntType, resolve = _.ctx.source.map(Action(_)))
+      )
+    )
+
+    Schema(Query, Some(Mutation), Some(Subscription))
+  }
+
+}

--- a/src/test/scala/io/github/dexclaimation/overlayer/websocket/SubscriptionsTransportWsTest.scala
+++ b/src/test/scala/io/github/dexclaimation/overlayer/websocket/SubscriptionsTransportWsTest.scala
@@ -1,0 +1,165 @@
+//
+//  SubscriptionsTransportWsTest.scala
+//  over-layer
+//
+//  Created by d-exclaimation on 11:07 PM.
+//
+
+package io.github.dexclaimation.overlayer.websocket
+
+import akka.http.scaladsl.model.ws.{Message, TextMessage}
+import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.{Inlet, KillSwitches, Outlet}
+import io.github.dexclaimation.overlayer.OverTransportLayer
+import org.junit.Test
+import sangria.execution.Executor
+import sangria.parser.QueryParser
+import spray.json.{JsObject, JsString}
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class SubscriptionsTransportWsTest {
+
+  import Shared._
+
+  private val transport = OverTransportLayer(demoSchema, ())
+
+  private def wait(millis: Int)(action: => Unit): Unit = {
+    Thread.sleep(millis)
+    action
+  }
+
+  /**
+   * '''Websocket'''
+   *
+   * 1. Properly Setup Flow Test
+   */
+  @Test def properlySetupFlow(): Unit = {
+
+    val flow = transport.flow(ctx)
+
+    val inMatch: PartialFunction[Any, Unit] = {
+      case _: Inlet[Message] => ()
+    }
+
+    val outMatch: PartialFunction[Any, Unit] = {
+      case _: Outlet[Message] => ()
+    }
+
+    inMatch(flow.shape.in)
+    outMatch(flow.shape.out)
+  }
+
+  @Test def initializeConnection(): Unit = {
+    val source =
+      Source(
+        Seq(
+          JsObject(
+            "type" -> JsString("connection_init"),
+            "payload" -> JsObject.empty
+          )
+        )
+      )
+        .map(_.compactPrint)
+        .map(TextMessage.Strict.apply)
+
+    val sink = Sink.takeLast[TextMessage.Strict](2)
+    val kill = KillSwitches.shared("ok")
+
+    val (_, fut) = transport.flow(ctx)
+      .via(kill.flow)
+      .runWith(source, sink)
+
+    wait(100) {
+      kill.shutdown()
+    }
+
+    val store = Await.result(fut, Duration.Inf)
+    assert(store.nonEmpty)
+    assert(store.length == 2)
+    assert(store.last.text == JsObject("type" -> JsString("ka")).compactPrint)
+    assert(store.head.text == JsObject("type" -> JsString("connection_ack")).compactPrint)
+  }
+
+  @Test def startOperation(): Unit = {
+    val source =
+      Source(
+        Seq(
+          JsObject(
+            "type" -> JsString("connection_init"),
+            "payload" -> JsObject.empty
+          ),
+          JsObject(
+            "type" -> JsString("start"),
+            "id" -> JsString("1"),
+            "payload" -> JsObject(
+              "query" -> JsString("subscription { state }")
+            )
+          )
+        )
+      )
+        .map(_.compactPrint)
+        .map(TextMessage.Strict.apply)
+
+    val kill = KillSwitches.shared("good")
+    val sink = Sink.takeLast[TextMessage.Strict](1)
+    val (_, fut) = transport.flow(ctx)
+      .via(kill.flow)
+      .runWith(source, sink)
+
+    QueryParser.parse("mutation { increment }")
+      .map { doc => Executor.execute(demoSchema, doc, ctx, ()) }
+
+    wait(100) {
+      kill.shutdown()
+    }
+
+    val Seq(TextMessage.Strict(_)) = Await.result(fut, Duration.Inf)
+
+  }
+
+
+  @Test def faultyStartOperation(): Unit = {
+    val source = Source(
+      Seq(
+        JsObject(
+          "type" -> JsString("connection_init"),
+          "payload" -> JsObject.empty
+        ),
+        JsObject(
+          "type" -> JsString("start"),
+          "id" -> JsString("1"),
+          "payload" -> JsObject(
+            "query" -> JsString("query { state }")
+          )
+        )
+      )
+    )
+      .map(_.compactPrint)
+      .map(TextMessage.Strict.apply)
+
+
+    val sink = Sink.takeLast[TextMessage.Strict](1)
+
+    val kill = KillSwitches.shared("ok")
+
+    val (_, future) = transport.flow(ctx)
+      .via(kill.flow)
+      .runWith(source, sink)
+
+    wait(100) {
+      kill.shutdown()
+    }
+
+    val messages = Await.result(future, Duration.Inf)
+    assert(messages.last.text
+      .equals(
+        JsObject(
+          "type" -> JsString("error"),
+          "payload" -> JsString("Cannot perform operation other than subscriptions through websocket")
+        ).compactPrint
+      )
+    )
+  }
+}


### PR DESCRIPTION
## Description

Setup primary unit test for `subscriptions-transport-ws`

### Websocket capabilities
1. ~Using a simple schema, does [OverTransportLayer](https://github.com/d-exclaimation/over-layer/blob/main/src/main/scala/io/github/dexclaimation/overlayer/OverTransportLayer.scala) properly set up `Flow`.~
2. ~Using a simple schema, does [OverTransportLayer](https://github.com/d-exclaimation/over-layer/blob/main/src/main/scala/io/github/dexclaimation/overlayer/OverTransportLayer.scala) properly respond to `subscriptions-transport-ws` messages.~
    a. ~Respond  with `GQL_CONNECTION_INIT` with `GQL_CONNECTION_ACK` and `GQL_CONNECTION_KEEP_ALIVE`.~
    b. ~Handle `GQL_START` if query is correct and register a stream.~
    c. ~Able to push `GQL_DATA` after successful `GQL_START`.~
    d. ~Able to stop pushing `GQL_DATA` after `GQL_STOP`.~